### PR TITLE
feat: add visual sunken effect for adjacent tiles on right-click

### DIFF
--- a/js/display.js
+++ b/js/display.js
@@ -20,8 +20,9 @@ function displayGrid() {
             if (playing) {
                 button.setAttribute("onclick", "clickButton(" + i + ", " + j + ")")
                 button.setAttribute("oncontextmenu", "flagButton(" + i + ", " + j + "); return false;")
-                button.setAttribute("onmousedown", 'smiley("img/wow.png")')
-                button.setAttribute("onmouseup", 'smiley("img/ok.png")')
+                button.setAttribute("onmousedown", "smiley('img/wow.png'); if(event.button==2) sinkNeighbors(" + i + ", " + j + ", true)")
+                button.setAttribute("onmouseup", "smiley('img/ok.png'); sinkNeighbors(" + i + ", " + j + ", false)")
+                button.setAttribute("onmouseleave", "sinkNeighbors(" + i + ", " + j + ", false)")
             }
 
             if (grid[i][j].isFlagged) {
@@ -171,6 +172,21 @@ function toggleWindowVisibility() {
             running = true
         } else if (playing && firstClick) { // ensures the window is correctly displayed after it is reopened
             resetGame()
+        }
+    }
+}
+
+function sinkNeighbors(x, y, sink) {
+    if (!grid[x][y].isClicked) return;
+    for (let i_off = -1; i_off <= 1; i_off++) {
+        for (let j_off = -1; j_off <= 1; j_off++) {
+            let nx = x + i_off, ny = y + j_off;
+            if (nx >= 0 && nx < difficulty.rows && ny >= 0 && ny < difficulty.cols) {
+                let btn = document.getElementById('grid').rows[nx].cells[ny].firstChild;
+                if (btn && btn.classList.contains('field_button') && !grid[nx][ny].isFlagged) {
+                    btn.classList.toggle('field_button_sunken', sink);
+                }
+            }
         }
     }
 }

--- a/style.css
+++ b/style.css
@@ -186,7 +186,7 @@ li {
     background-color: rgb(192, 192, 192);
 }
 
-.field_button:active {
+.field_button:active, .field_button_sunken {
     border-top: solid rgb(117, 117, 117) 1px;
     border-left: solid rgb(117, 117, 117) 1px;
     border-bottom: solid transparent 3px;


### PR DESCRIPTION
This PR adds a visual 'sunken' effect to adjacent tiles when right-clicking on a revealed square, improving the user experience by providing visual feedback of the chording area. It also maintains the standard right-click behavior for flagging unrevealed tiles.